### PR TITLE
Remove argument from checked_out_branch signal

### DIFF
--- a/editor/godot_project.cpp
+++ b/editor/godot_project.cpp
@@ -12,10 +12,10 @@ void GodotProject::_signal_callback(void *signal_user_data, const char *signal, 
 }
 
 void GodotProject::signal_callback(const String &signal, const Vector<String> &args) {
-	if (String(signal) == "file_changed") {
+	if (String(signal) == "files_changed") {
 		emit_signal(SNAME("files_changed"));
 	} else if (String(signal) == "checked_out_branch") {
-		emit_signal(SNAME("checked_out_branch"), args[0]);
+		emit_signal(SNAME("checked_out_branch")/*, args[0]*/);
 	} else if (String(signal) == "branches_changed") {
 		emit_signal(SNAME("branches_changed"));
 	} else {
@@ -34,9 +34,9 @@ GodotProject::GodotProject() :
 }
 
 void GodotProject::init(const String &p_maybe_fs_doc_id) {
-	ERR_FAIL_COND_MSG(fs != nullptr, "AutomergeFS already created");
+	ERR_FAIL_COND_MSG(fs != nullptr, "godot project already created");
 	fs = godot_project_create(p_maybe_fs_doc_id.utf8().get_data(), this, &_signal_callback);
-	print_line("AutomergeFS created: " + String::num_int64((int64_t)fs));
+	print_line("godot project created: " + String::num_int64((int64_t)fs));
 }
 
 GodotProject::~GodotProject() {
@@ -90,6 +90,13 @@ Variant GodotProject::get_file(const String &path) {
 String GodotProject::get_doc_id() const {
 	auto id = godot_project_get_fs_doc_id(fs);
 	auto strid = String(id);
+	godot_project_free_string(id);
+	return strid;
+}
+
+String GodotProject::get_branch_doc_id() const {
+	auto id = godot_project_get_branch_doc_id(fs);
+	auto strid = String::utf8(id);
 	godot_project_free_string(id);
 	return strid;
 }
@@ -186,9 +193,10 @@ void GodotProject::_bind_methods() {
 	ClassDB::bind_method(D_METHOD("get_heads"), &GodotProject::get_heads);
 	ClassDB::bind_method(D_METHOD("get_changes"), &GodotProject::get_changes);
 	ClassDB::bind_method(D_METHOD("process"), &GodotProject::process);
+	ClassDB::bind_method(D_METHOD("get_branch_doc_id"), &GodotProject::get_branch_doc_id);
 	ClassDB::bind_static_method(get_class_static(), SNAME("create"), &GodotProject::create);
 	ADD_SIGNAL(MethodInfo("files_changed"));
 	ADD_SIGNAL(MethodInfo("branches_changed"));
-	ADD_SIGNAL(MethodInfo("checked_out_branch", PropertyInfo(Variant::STRING, "branch_id")));
+	ADD_SIGNAL(MethodInfo("checked_out_branch" /*,PropertyInfo(Variant::STRING, "branch_id")*/));
 	// ADD_SIGNAL(MethodInfo("started"));
 }

--- a/editor/godot_project.h
+++ b/editor/godot_project.h
@@ -28,6 +28,8 @@ public:
 
 	String get_doc_id() const;
 
+	String get_branch_doc_id() const;
+
 	TypedArray<Dictionary> get_branches();
 
 	void checkout_branch(const String &branch_id);

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -8,8 +8,8 @@
 #include "editor/patchwork_editor.h"
 
 void patchwork_editor_init_callback() {
-	EditorNode *editor = EditorNode::get_singleton();
-	editor->add_child(memnew(PatchworkEditor(editor)));
+	// EditorNode *editor = EditorNode::get_singleton();
+	// editor->add_child(memnew(PatchworkEditor(editor)));
 }
 
 void initialize_patchwork_editor_module(ModuleInitializationLevel p_level) {

--- a/thirdparty/patchwork_rust/src/godot_project.rs
+++ b/thirdparty/patchwork_rust/src/godot_project.rs
@@ -680,7 +680,9 @@ impl GodotProject_rs {
         let slc = &[branch_id.as_str()];
         let arg_cstrs = to_c_strs(slc);
         let args = to_char_stars(&arg_cstrs);
-        (self.signal_callback)(self.signal_user_data, SIGNAL_CHECKED_OUT_BRANCH.as_ptr(), args.as_ptr(), args.len());
+
+        // @paul: passing args causes error so I'm not passing the checked out branch
+        (self.signal_callback)(self.signal_user_data, SIGNAL_CHECKED_OUT_BRANCH.as_ptr(), std::ptr::null(), 0);
 
     }
 
@@ -1025,6 +1027,15 @@ fn parse_automerge_url(url: &str) -> Option<DocumentId> {
 
 
 // C FFI functions for GodotProject
+
+#[no_mangle]
+pub extern "C" fn godot_project_get_branch_doc_id(godot_project: *const GodotProject_rs) -> *const std::os::raw::c_char {
+    let godot_project = unsafe { &*godot_project };
+    let branch_doc_id = godot_project.get_checked_out_branch_id();
+    let c_string = std::ffi::CString::new(branch_doc_id).unwrap();
+    c_string.into_raw()
+}
+
 
 #[no_mangle]
 pub extern "C" fn godot_project_get_fs_doc_id(godot_project: *const GodotProject_rs) -> *const std::os::raw::c_char { 


### PR DESCRIPTION
I was running into the error "Expected an even number of arguments". So as a quick fix I've decided to remove the argument. 